### PR TITLE
Оптимизация Адаптеров

### DIFF
--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/base/BaseListDiffCallback.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/base/BaseListDiffCallback.java
@@ -1,0 +1,24 @@
+package ru.yandex.practicum.contacts.presentation.base;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.DiffUtil;
+
+
+public class BaseListDiffCallback<T extends ListDiffInterface<T>> extends DiffUtil.ItemCallback<T> {
+    @Override
+    public boolean areItemsTheSame(@NonNull T oldItem, @NonNull T newItem) {
+        return oldItem.theSameAs(newItem);
+    }
+
+    @Override
+    public boolean areContentsTheSame(@NonNull T oldItem, @NonNull T newItem) {
+        return oldItem.equals(newItem);
+    }
+
+    @Nullable
+    @Override
+    public Object getChangePayload(@NonNull T oldItem, @NonNull T newItem) {
+        return newItem;
+    }
+}

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/base/ListDiffInterface.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/base/ListDiffInterface.java
@@ -1,0 +1,13 @@
+package ru.yandex.practicum.contacts.presentation.base;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.DiffUtil;
+
+import ru.yandex.practicum.contacts.presentation.main.ContactUi;
+
+public interface ListDiffInterface<T>{
+
+    boolean theSameAs(@NonNull T oldItem);
+
+    boolean equals(Object o);
+}

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/filter/FilterContactTypeAdapter.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/filter/FilterContactTypeAdapter.java
@@ -5,11 +5,9 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.AdapterListUpdateCallback;
 import androidx.recyclerview.widget.AsyncDifferConfig;
 import androidx.recyclerview.widget.AsyncListDiffer;
-import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.List;
@@ -17,6 +15,7 @@ import java.util.function.Consumer;
 
 import ru.yandex.practicum.contacts.databinding.ItemFilterBinding;
 import ru.yandex.practicum.contacts.model.ContactType;
+import ru.yandex.practicum.contacts.presentation.base.BaseListDiffCallback;
 import ru.yandex.practicum.contacts.presentation.filter.model.FilterContactType;
 import ru.yandex.practicum.contacts.presentation.filter.model.FilterContactTypeUi;
 import ru.yandex.practicum.contacts.utils.model.ContactTypeUtils;
@@ -26,7 +25,7 @@ public class FilterContactTypeAdapter extends RecyclerView.Adapter<FilterContact
 
     private final AsyncListDiffer<FilterContactTypeUi> differ = new AsyncListDiffer<>(
             new AdapterListUpdateCallback(this),
-            new AsyncDifferConfig.Builder<>(new ListDiffCallback()).build()
+            new AsyncDifferConfig.Builder<>(new BaseListDiffCallback<FilterContactTypeUi>()).build()
     );
 
     private final Consumer<FilterContactTypeUi> clickListener;
@@ -83,25 +82,6 @@ public class FilterContactTypeAdapter extends RecyclerView.Adapter<FilterContact
                 binding.logo.setVisibility(View.VISIBLE);
                 binding.logo.setImageResource(iconRes);
             }
-        }
-    }
-
-    static class ListDiffCallback extends DiffUtil.ItemCallback<FilterContactTypeUi> {
-
-        @Override
-        public boolean areItemsTheSame(@NonNull FilterContactTypeUi oldItem, @NonNull FilterContactTypeUi newItem) {
-            return oldItem.getContactType() == newItem.getContactType();
-        }
-
-        @Override
-        public boolean areContentsTheSame(@NonNull FilterContactTypeUi oldItem, @NonNull FilterContactTypeUi newItem) {
-            return oldItem.equals(newItem);
-        }
-
-        @Nullable
-        @Override
-        public Object getChangePayload(@NonNull FilterContactTypeUi oldItem, @NonNull FilterContactTypeUi newItem) {
-            return newItem;
         }
     }
 }

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/filter/model/FilterContactTypeUi.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/filter/model/FilterContactTypeUi.java
@@ -2,7 +2,9 @@ package ru.yandex.practicum.contacts.presentation.filter.model;
 
 import androidx.annotation.NonNull;
 
-public class FilterContactTypeUi {
+import ru.yandex.practicum.contacts.presentation.base.ListDiffInterface;
+
+public class FilterContactTypeUi implements ListDiffInterface<FilterContactTypeUi> {
 
     private final FilterContactType contactType;
     private final boolean selected;
@@ -36,5 +38,10 @@ public class FilterContactTypeUi {
         int result = contactType.hashCode();
         result = 31 * result + (selected ? 1 : 0);
         return result;
+    }
+
+    @Override
+    public boolean theSameAs(@NonNull FilterContactTypeUi oldItem) {
+        return this.getContactType() == oldItem.getContactType();
     }
 }

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/main/ContactAdapter.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/main/ContactAdapter.java
@@ -8,12 +8,10 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.AdapterListUpdateCallback;
 import androidx.recyclerview.widget.AsyncDifferConfig;
 import androidx.recyclerview.widget.AsyncListDiffer;
-import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.bumptech.glide.Glide;
@@ -23,12 +21,14 @@ import java.util.Objects;
 
 import ru.yandex.practicum.contacts.R;
 import ru.yandex.practicum.contacts.databinding.ItemContactBinding;
+import ru.yandex.practicum.contacts.presentation.base.BaseListDiffCallback;
+
 
 public class ContactAdapter extends RecyclerView.Adapter<ContactAdapter.ViewHolder> {
 
     private final AsyncListDiffer<ContactUi> differ = new AsyncListDiffer<>(
             new AdapterListUpdateCallback(this),
-            new AsyncDifferConfig.Builder<>(new ListDiffCallback()).build()
+            new AsyncDifferConfig.Builder<>(new BaseListDiffCallback<ContactUi>()).build()
     );
 
     @NonNull
@@ -90,25 +90,6 @@ public class ContactAdapter extends RecyclerView.Adapter<ContactAdapter.ViewHold
                     .fallback(drawable)
                     .error(drawable)
                     .into(binding.contactPhoto);
-        }
-    }
-
-    static class ListDiffCallback extends DiffUtil.ItemCallback<ContactUi> {
-
-        @Override
-        public boolean areItemsTheSame(@NonNull ContactUi oldItem, @NonNull ContactUi newItem) {
-            return oldItem.hashCode() == newItem.hashCode();
-        }
-
-        @Override
-        public boolean areContentsTheSame(@NonNull ContactUi oldItem, @NonNull ContactUi newItem) {
-            return oldItem.equals(newItem);
-        }
-
-        @Nullable
-        @Override
-        public Object getChangePayload(@NonNull ContactUi oldItem, @NonNull ContactUi newItem) {
-            return newItem;
         }
     }
 }

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/main/ContactUi.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/main/ContactUi.java
@@ -1,12 +1,14 @@
 package ru.yandex.practicum.contacts.presentation.main;
 
 import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.DiffUtil;
 
 import java.util.List;
 
 import ru.yandex.practicum.contacts.model.ContactType;
+import ru.yandex.practicum.contacts.presentation.base.ListDiffInterface;
 
-public class ContactUi {
+public class ContactUi implements ListDiffInterface<ContactUi> {
 
     private final String name;
     private final String phone;
@@ -61,5 +63,10 @@ public class ContactUi {
         result = 31 * result + photo.hashCode();
         result = 31 * result + types.hashCode();
         return result;
+    }
+
+    @Override
+    public boolean theSameAs(@NonNull ContactUi oldItem) {
+        return this.hashCode() == oldItem.hashCode();
     }
 }

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/sort/SortTypeAdapter.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/sort/SortTypeAdapter.java
@@ -17,13 +17,15 @@ import java.util.function.Consumer;
 
 import ru.yandex.practicum.contacts.R;
 import ru.yandex.practicum.contacts.databinding.ItemSortBinding;
+import ru.yandex.practicum.contacts.presentation.base.BaseListDiffCallback;
+import ru.yandex.practicum.contacts.presentation.filter.model.FilterContactTypeUi;
 import ru.yandex.practicum.contacts.presentation.sort.model.SortType;
 
 public class SortTypeAdapter extends RecyclerView.Adapter<SortTypeAdapter.ViewHolder> {
 
     private final AsyncListDiffer<SortTypeUI> differ = new AsyncListDiffer<>(
             new AdapterListUpdateCallback(this),
-            new AsyncDifferConfig.Builder<>(new ListDiffCallback()).build()
+            new AsyncDifferConfig.Builder<>(new BaseListDiffCallback<SortTypeUI>()).build()
     );
 
     private final Consumer<SortTypeUI> clickListener;
@@ -86,25 +88,6 @@ public class SortTypeAdapter extends RecyclerView.Adapter<SortTypeAdapter.ViewHo
                 default:
                     throw new IllegalArgumentException("Not supported SortType");
             }
-        }
-    }
-
-    static class ListDiffCallback extends DiffUtil.ItemCallback<SortTypeUI> {
-
-        @Override
-        public boolean areItemsTheSame(@NonNull SortTypeUI oldItem, @NonNull SortTypeUI newItem) {
-            return oldItem.getSortType() == newItem.getSortType();
-        }
-
-        @Override
-        public boolean areContentsTheSame(@NonNull SortTypeUI oldItem, @NonNull SortTypeUI newItem) {
-            return oldItem.equals(newItem);
-        }
-
-        @Nullable
-        @Override
-        public Object getChangePayload(@NonNull SortTypeUI oldItem, @NonNull SortTypeUI newItem) {
-            return newItem;
         }
     }
 }

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/sort/SortTypeUI.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/sort/SortTypeUI.java
@@ -2,9 +2,10 @@ package ru.yandex.practicum.contacts.presentation.sort;
 
 import androidx.annotation.NonNull;
 
+import ru.yandex.practicum.contacts.presentation.base.ListDiffInterface;
 import ru.yandex.practicum.contacts.presentation.sort.model.SortType;
 
-public class SortTypeUI {
+public class SortTypeUI implements ListDiffInterface<SortTypeUI> {
 
     private final SortType sortType;
     private final boolean selected;
@@ -38,5 +39,10 @@ public class SortTypeUI {
         int result = sortType.hashCode();
         result = 31 * result + (selected ? 1 : 0);
         return result;
+    }
+
+    @Override
+    public boolean theSameAs(@NonNull SortTypeUI oldItem) {
+        return this.getSortType() == oldItem.getSortType();
     }
 }


### PR DESCRIPTION
Создан дженерик интерфейс ListDiffInterface сравнения объектов любых типов. В него перенесено два метода theSameAs и equals. Реализация интерфейса с соответствующим уточнением типов данных осуществляется в ContactUi, SortTypeUI, FilterContactTypeUi.  
Реализация абстрактного класса ItemCallback перенесена из ContactAdapter, FilterContactTypeAdapter, SortTypeAdapter в BaseListDiffCallback.
Объект differ в ContactUi, SortTypeUI, FilterContactTypeUi переориентирован на BaseListDiffCallback.
Классы ListDiffCallback в ContactAdapter, FilterContactTypeAdapter, SortTypeAdapter, которые ранее реализовывали абстрактный класс DiffUtil.ItemCallback, удалены.